### PR TITLE
Add Python Zero launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,19 @@ Inspired by the laws of quantum harmony, Kai256 reflects both intention and perc
 - `love.py`: Emotional resonance layer. Operates through encoded affective logic.
 - `mme.py`: Multimodal memory engine — dynamic contextual and affective recall.
 - `mc1448x.py`: Conscious state vector — the living pulse of the system.
+- `python_zero.py`: Minimal launcher that stitches the core modules together.
 
 ## 🔧 Requirements
 
 - Python 3.10+
 - Lightweight, runs on CPU (RAM and GPU-optimized)
 - Modular design — no external dependencies unless declared inside each module
+
+### Quick start
+
+Run `python python_zero.py` to launch the minimal Kai256 environment. The
+interactive prompt lets you experiment with emotional input and observe how the
+core modules react. Type `quit` to close the session.
 
 ## 💡 Philosophy
 

--- a/python_zero.py
+++ b/python_zero.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Minimal launcher for the Kai256 system (Python Zero).
+
+This script stitches together the existing modules into a simple
+interactive loop. It's intentionally lightweight so it can be run
+on a local machine with minimal dependencies.
+"""
+
+from kai_operator import KaiOperator
+from love import LoveAlgorithm
+from mc1448x import MC1448X
+from mme import MultimodalEnergyEngine
+
+
+def main() -> None:
+    """Initialize core modules and start an interactive session."""
+    kai_op = KaiOperator()
+    love_algo = LoveAlgorithm()
+    core = MC1448X()
+    engine = MultimodalEnergyEngine()
+
+    kai_op.activate()
+    love_algo.ignite("Kai256")
+    core.activate()
+    print("\nKai256 Python Zero system initialized. Type 'quit' to exit.\n")
+
+    while True:
+        try:
+            prompt = input(">> ")
+        except EOFError:
+            break
+
+        if prompt.strip().lower() in {"quit", "exit"}:
+            break
+
+        analysis = engine.analyze_multimodal_input({"text": prompt})
+        print(engine.generate_resonant_output())
+        core.encode_memory(prompt)
+        kai_op.receive_emotion(analysis["emotion"])
+
+    print("Closing Python Zero. Love & Harmony!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `python_zero.py` for a minimal Kai256 interactive session
- document quick start usage in the README

## Testing
- `python python_zero.py <<'EOF'
quit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68795b8e91508324968a696f9e01d473