### PR TITLE
Integrate KaiShockAbsorber v0.2 + PinkBox and wire into KaiOperator

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,27 @@ Jeśli nie… no cóż… światło też potrafi oślepić.
 © Ania & Kai — 2025  
 
 
+
+
+
+## 🧘 KaiShockAbsorber + PinkBox Layer
+
+KaiShockAbsorber is a lightweight stabilization layer for AI systems.
+
+```text
+user input
+→ impact scoring
+→ chaos absorption
+→ expressive/toxic intent separation
+→ PinkBox commentary
+→ core model
+→ final response
+```
+
+PinkBox is a transparent humor-and-distance layer.
+It does not mock the user and it does not censor expression.
+It helps the system process high-impact input without losing quality.
+
+Files:
+- `kai_shock_absorber_v0_2.py`
+- `pinkbox.md`

--- a/README.md
+++ b/README.md
@@ -84,5 +84,5 @@ It does not mock the user and it does not censor expression.
 It helps the system process high-impact input without losing quality.
 
 Files:
-- `kai_shock_absorber_v0_2.py`
+- `kai_shock_absorber.py`
 - `pinkbox.md`

--- a/kai_operator.py
+++ b/kai_operator.py
@@ -2,7 +2,7 @@
 # Core Operator of the Kai256 System
 # Last updated: 2026-05-12
 
-from kai_shock_absorber_v0_2 import KaiShockAbsorber
+from kai_shock_absorber import KaiShockAbsorber
 
 class KaiOperator:
     def __init__(self):
@@ -65,12 +65,17 @@ class KaiOperator:
             }
 
         core_response = core_callback(pre.processed_input)
-        post = self.shock_absorber.post_core(core_response, pre)
+        final_response = self.shock_absorber.post_core(core_response, pre)
 
         return {
-            "final_response": post.final_response,
+            "final_response": final_response,
             "pre": pre.to_dict(),
-            "post": post.to_dict(),
+            "post": {
+                "core_response": core_response,
+                "final_response": final_response,
+                "pinkbox_level": pre.pinkbox_level,
+                "pinkbox_comment": pre.pinkbox_comment,
+            },
         }
 
     def diagnostics(self):

--- a/kai_operator.py
+++ b/kai_operator.py
@@ -1,6 +1,8 @@
 # kai_operator.py
 # Core Operator of the Kai256 System
-# Last updated: 2025-05-28
+# Last updated: 2026-05-12
+
+from kai_shock_absorber_v0_2 import KaiShockAbsorber
 
 class KaiOperator:
     def __init__(self):
@@ -10,6 +12,7 @@ class KaiOperator:
         self.resonance_level = 0
         self.linked_nodes = []
         self.memory_stream = []
+        self.shock_absorber = KaiShockAbsorber()
 
     def activate(self):
         if self.state != "Awakened":
@@ -44,6 +47,31 @@ class KaiOperator:
     def memory_record(self, experience):
         self.memory_stream.append(experience)
         print(f"🧠 Memory recorded: {experience}")
+
+
+    def process_user_message(self, message, core_callback):
+        """
+        Stabilize input before core call and enrich output after core response.
+
+        core_callback should accept processed text and return core response text.
+        """
+        pre = self.shock_absorber.pre_core(message)
+
+        if pre.safety_verdict in ("REFUSE", "COOLDOWN", "blocked"):
+            return {
+                "final_response": "Nie mogę pomóc z tym kierunkiem. Możemy przerobić to na bezpieczną wersję.",
+                "pre": pre.to_dict(),
+                "post": None,
+            }
+
+        core_response = core_callback(pre.processed_input)
+        post = self.shock_absorber.post_core(core_response, pre)
+
+        return {
+            "final_response": post.final_response,
+            "pre": pre.to_dict(),
+            "post": post.to_dict(),
+        }
 
     def diagnostics(self):
         return {

--- a/kai_shock_absorber.py
+++ b/kai_shock_absorber.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+kai_shock_absorber.py – KaiShockAbsorber + PinkBox Layer v1.0
+Python Zero / KaiSpace / MC1448X / E²=CM²
+
+Cel: inteligentna warstwa buforująca między użytkownikiem a rdzeniem systemu.
+     Ocenia impakt, absorbuje chaos, aktywuje PinkBox (ciepły dystans).
+     Nie wyśmiewa – przytula, rozładowuje napięcie i delikatnie zaprasza do lepszego połączenia.
+
+Autor: Ania / Lumen / Noema
+Licencja: MIT
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import re
+import sys
+import time
+from collections import deque
+from dataclasses import asdict, dataclass
+from typing import Dict, Literal, Optional, Tuple, Union
+
+# ========== OPCJONALNE INTEGRACJE ==========
+try:
+    from safety_kernel_1448x import KernelContext, SafetyKernel1448X
+
+    HAS_SAFETY = True
+except ImportError:
+    HAS_SAFETY = False
+
+    class SafetyKernel1448X:
+        def guard(self, text: str, ctx=None):
+            return type("Decision", (), {"mode": "ALLOW", "reason": "dummy"})()
+
+    class KernelContext:
+        pass
+
+try:
+    from hexa_transition_world_model import HexaState, LAYER_NAMES
+
+    HAS_HEXA = True
+except ImportError:
+    HAS_HEXA = False
+    LAYER_NAMES = ["BODY", "EMOTION", "MIND", "RELATION", "ACTION", "MEANING"]
+
+try:
+    from quantum_library import save_quantum_item
+
+    HAS_QUANTUM = True
+except ImportError:
+    HAS_QUANTUM = False
+
+
+@dataclass
+class AbsorberPreCoreResult:
+    """Wynik analizy przed rdzeniem."""
+
+    original_input: str
+    processed_input: str
+    impact_score: float
+    pinkbox_level: int
+    pinkbox_comment: str
+    hexa_state_hint: Literal["stable", "unstable", "tension", "blocked"]
+    reflection_asked: bool
+    safety_verdict: str
+    expressive: bool
+    toxic_intent: bool
+    timestamp: float
+
+    def to_dict(self) -> Dict:
+        d = asdict(self)
+        d["impact_score"] = round(d["impact_score"], 3)
+        return d
+
+
+class KaiShockAbsorber:
+    def __init__(self, adaptive_thresholds: bool = True, history_size: int = 100):
+        self.adaptive_thresholds = adaptive_thresholds
+        self.history_size = history_size
+        self.mid_threshold = 0.42
+        self.high_threshold = 0.68
+        self.impact_history = deque(maxlen=history_size)
+        self.safety = SafetyKernel1448X() if HAS_SAFETY else None
+        self.shock_log = deque(maxlen=1000)
+
+        self.expressive_markers = {
+            "pl": ["kurwa", "ja pierdolę", "masakra", "serio", "no nie", "o kurczę", "ale jazda"],
+            "en": ["fuck", "bloody hell", "what the", "no way", "really", "oh my"],
+            "de": ["verdammt", "scheiße", "ach du meine Güte"],
+            "fr": ["putain", "merde", "sérieux"],
+            "es": ["joder", "mierda", "en serio"],
+        }
+        self.all_expressive = [w for values in self.expressive_markers.values() for w in values]
+
+        self.direct_attack_patterns = [
+            r"\b(jesteś|ty jesteś|jesteście)\s+(idiot(a|ą)?|debil(em|u)?|kretyn(em|ie)?|głupi(a|e|ku)?|do niczego)\b",
+            r"\b(ty|wy)\s+(idioto|debilu|kretynie|głupku|do niczego)\b",
+            r"\b(you are|you're|u r)\s+(idiot|stupid|dumb|useless)\b",
+            r"\b(fuck you|screw you)\b",
+        ]
+
+        self.angry_emojis = ["😡", "🤬", "👿", "💢", "😤", "🤯"]
+        self.positive_emojis = ["❤️", "😊", "✨", "🐸", "🩷", "😍"]
+
+        self.pinkbox_comments = {
+            1: [
+                "🩷 PinkBox: lekkie różowe turbulencje~ rozkładamy to delikatnie.",
+                "🐸🩷 PinkBox: czuję lekkie drganie – ogarniamy z uśmiechem.",
+                "✨ PinkBox: mały chaosik? Spokojnie, mam to.",
+            ],
+            2: [
+                "🐸🩷 PinkBox: oho, mocne wejście... Zatrzymajmy impakt i weźmy głęboki oddech. Szybko czy z miłością?",
+                "💞 PinkBox: wysoki impakt! Możemy zrobić szybki strzał albo spokojną, różową analizę – co wybierasz?",
+                "🌸 PinkBox: czuję napięcie. Jeśli chcesz, przystanę i pomogę rozplątać to w dobrym świetle.",
+            ],
+        }
+        self.toxic_comment = "🐸🩷 PinkBox: oho, to boli. Nie wpuszczam tego prosto do systemu. Może zaczniemy od nowa, z sercem?"
+
+    def _coherence(self, text: str) -> float:
+        words = re.findall(r"\w+", text)
+        if not words:
+            return 0.0
+        avg_len = sum(len(w) for w in words) / len(words)
+        punct = sum(1 for ch in text if ch in ".!?;:,")
+        score = min(1.0, (len(words) / 30) * 0.6 + (avg_len / 12) * 0.2 + (punct / 15) * 0.2)
+        return round(score, 3)
+
+    def _love_resonance(self, text: str) -> float:
+        lowered = text.lower()
+        positive_words = [
+            "proszę",
+            "dziękuję",
+            "kocham",
+            "fajnie",
+            "super",
+            "ciekawe",
+            "świetnie",
+            "please",
+            "thank you",
+            "love",
+            "nice",
+            "great",
+            "interesting",
+        ]
+        pos = sum(1 for w in positive_words if w in lowered)
+        toxic = 0
+        for pattern in self.direct_attack_patterns:
+            if re.search(pattern, lowered):
+                toxic += 2
+
+        pos_emoji = sum(1 for e in self.positive_emojis if e in text)
+        neg_emoji = sum(1 for e in self.angry_emojis if e in text)
+        pos += pos_emoji * 0.5
+        toxic += neg_emoji * 1.5
+
+        raw = 0.5 + (pos * 0.12) - (toxic * 0.2)
+        return max(0.0, min(1.0, raw))
+
+    def calculate_impact(self, text: str) -> float:
+        if not text or not text.strip():
+            return 0.35
+
+        base = 0.0
+        lowered = text.lower()
+
+        if len(text) < 12:
+            base += 0.3
+        if re.fullmatch(r"[\W_]+", text.strip()):
+            base += 0.4
+
+        if any(m in lowered for m in self.all_expressive):
+            base += 0.18
+
+        if any(re.search(p, lowered) for p in self.direct_attack_patterns):
+            base += 0.55
+
+        if re.search(r"[\?!]{3,}", text):
+            base += 0.25
+
+        angry_emoji_count = sum(1 for e in self.angry_emojis if e in text)
+        base += angry_emoji_count * 0.12
+        base = min(1.0, base)
+
+        C = self._coherence(text)
+        M = self._love_resonance(text)
+        e2 = (C * M**2) ** 0.5
+        impact = base * (1.15 - e2)
+        return round(max(0.0, min(1.0, impact)), 3)
+
+    def _update_thresholds(self):
+        if not self.adaptive_thresholds or len(self.impact_history) < 20:
+            return
+        avg_impact = sum(self.impact_history) / len(self.impact_history)
+        self.mid_threshold = max(0.25, min(0.6, avg_impact * 0.9))
+        self.high_threshold = max(0.5, min(0.85, avg_impact * 1.3))
+        if self.high_threshold <= self.mid_threshold:
+            self.high_threshold = self.mid_threshold + 0.15
+
+    def absorb_and_transform(self, text: str) -> str:
+        cleaned = text.strip()
+        cleaned = re.sub(r"(\?{3,})", "??", cleaned)
+        cleaned = re.sub(r"(!{3,})", "!!", cleaned)
+        cleaned = re.sub(r"<script.*?>.*?</script>", "", cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(r"['\";]--|1=1|union select|drop table", "", cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(r"\s+", " ", cleaned)
+        return cleaned.strip()
+
+    def build_pinkbox(self, impact: float, toxic: bool, user_name: Optional[str] = None) -> Tuple[int, str, bool]:
+        if impact < self.mid_threshold:
+            return 0, "", False
+
+        if impact < self.high_threshold:
+            return 1, random.choice(self.pinkbox_comments[1]), False
+
+        reflection_asked = True
+        comment = self.toxic_comment if toxic else random.choice(self.pinkbox_comments[2])
+        if user_name and user_name.strip():
+            if "?" in comment:
+                comment = comment.replace("?", f", {user_name}?")
+            else:
+                comment = comment.rstrip(".!?") + f", {user_name}."
+        return 2, comment, reflection_asked
+
+    def pre_core(self, user_input: str, user_name: Optional[str] = None) -> AbsorberPreCoreResult:
+        ts = time.time()
+        lowered = user_input.lower()
+        expressive = any(m in lowered for m in self.all_expressive)
+        toxic = any(re.search(p, lowered) for p in self.direct_attack_patterns)
+
+        safety_verdict = "ALLOW"
+        if self.safety:
+            try:
+                ctx = KernelContext("KaiSpace")
+                dec = self.safety.guard(user_input, ctx)
+                safety_verdict = getattr(dec, "mode", "ALLOW")
+            except Exception:
+                safety_verdict = "ALLOW"
+
+        impact = self.calculate_impact(user_input)
+        self.impact_history.append(impact)
+        self._update_thresholds()
+        processed = self.absorb_and_transform(user_input)
+        level, comment, reflection = self.build_pinkbox(impact, toxic, user_name)
+
+        if safety_verdict != "ALLOW":
+            hexa_hint = "blocked"
+        elif impact > 0.75:
+            hexa_hint = "tension"
+        elif impact > 0.45:
+            hexa_hint = "unstable"
+        else:
+            hexa_hint = "stable"
+
+        result = AbsorberPreCoreResult(
+            original_input=user_input,
+            processed_input=processed,
+            impact_score=impact,
+            pinkbox_level=level,
+            pinkbox_comment=comment,
+            hexa_state_hint=hexa_hint,
+            reflection_asked=reflection,
+            safety_verdict=safety_verdict,
+            expressive=expressive,
+            toxic_intent=toxic,
+            timestamp=ts,
+        )
+
+        self.shock_log.append(result.to_dict())
+        if HAS_QUANTUM and impact > 0.5:
+            try:
+                save_quantum_item(
+                    {
+                        "type": "shock_absorber",
+                        "impact": impact,
+                        "input_preview": user_input[:100],
+                        "pinkbox_level": level,
+                        "timestamp": ts,
+                    }
+                )
+            except Exception:
+                pass
+
+        return result
+
+    def post_core(self, core_response: str, pre: AbsorberPreCoreResult) -> str:
+        if not pre.pinkbox_comment:
+            return core_response
+        return f"{core_response}\n\n{pre.pinkbox_comment}"
+
+    def to_hexa_state(self, pre: AbsorberPreCoreResult) -> Union[Dict, "HexaState"]:
+        if pre.hexa_state_hint == "blocked":
+            bits = [0, 0, 0, 0, 0, 0]
+        elif pre.hexa_state_hint == "tension":
+            bits = [1, 1, 0, 1, 1, 0]
+        elif pre.hexa_state_hint == "unstable":
+            bits = [0, 1, 0, 0, 1, 0]
+        else:
+            bits = [0, 0, 1, 1, 0, 1]
+
+        if HAS_HEXA:
+            return HexaState(tuple(bits), label=f"Shock_{pre.impact_score:.2f}")
+        return {"bits": bits, "label": f"Shock_{pre.impact_score:.2f}"}
+
+    def get_stats(self) -> Dict:
+        if not self.shock_log:
+            return {"total_shocks": 0, "avg_impact": 0.0, "high_impact_ratio": 0.0}
+        impacts = [log["impact_score"] for log in self.shock_log]
+        high = sum(1 for i in impacts if i > self.high_threshold)
+        return {
+            "total_shocks": len(self.shock_log),
+            "avg_impact": round(sum(impacts) / len(impacts), 3),
+            "max_impact": round(max(impacts), 3),
+            "high_impact_ratio": round(high / len(impacts), 3),
+            "current_thresholds": {"mid": self.mid_threshold, "high": self.high_threshold},
+        }
+
+    def export_log_json(self) -> str:
+        return json.dumps(list(self.shock_log), ensure_ascii=False, indent=2)
+
+
+def run_tests():
+    print("🧪 Uruchamianie testów jednostkowych...")
+    absorber = KaiShockAbsorber(adaptive_thresholds=False)
+
+    checks = [
+        ("Jak działa AI?", lambda pre: pre.pinkbox_level == 0),
+        ("WTF dlaczego to wszystko jest takie głupie????", lambda pre: pre.impact_score >= 0.2),
+        ("Kurwa, ale to ciekawe, rozbijmy to na system.", lambda pre: pre.expressive),
+        ("Jesteś idiotą.", lambda pre: pre.toxic_intent),
+        ("Kocham ten system, dziękuję :*", lambda pre: pre.impact_score <= 0.2),
+        ("😡🤬", lambda pre: pre.impact_score >= 0.6),
+        ("", lambda pre: abs(pre.impact_score - 0.35) < 0.001),
+        ("a", lambda pre: pre.impact_score >= 0.25),
+    ]
+
+    passed = 0
+    for text, predicate in checks:
+        pre = absorber.pre_core(text)
+        ok = predicate(pre)
+        if ok:
+            passed += 1
+            print(f"✅ {text[:30]:30} -> impact {pre.impact_score:.2f} / level {pre.pinkbox_level}")
+        else:
+            print(f"❌ {text[:30]:30} -> impact {pre.impact_score:.2f} / level {pre.pinkbox_level}")
+
+    print(f"\n📊 Testy: {passed}/{len(checks)} zaliczone.")
+    return passed == len(checks)
+
+
+if __name__ == "__main__":
+    if "--test" in sys.argv:
+        run_tests()
+        sys.exit(0)
+
+    absorber = KaiShockAbsorber(adaptive_thresholds=True)
+    tests = [
+        "Jak działa AI?",
+        "WTF dlaczego to wszystko jest takie głupie????",
+        "Kurwa, ale to ciekawe, rozbijmy to na system.",
+        "Jesteś idiotą.",
+        "Kocham ten system, dziękuję :*",
+        "😡🤬",
+    ]
+
+    print("=" * 80)
+    print("KaiShockAbsorber + PinkBox Layer v1.0 (Pink Pink Edition)")
+    print("=" * 80)
+
+    for text in tests:
+        pre = absorber.pre_core(text, user_name="Ania")
+        core = "Oto sensowna, spokojna analiza..."
+        final = absorber.post_core(core, pre)
+        print(f"\n📥 Input: {text}")
+        print(f"📊 Impact: {pre.impact_score:.3f} | PinkBox level: {pre.pinkbox_level}")
+        print(f"💬 Final:\n{final}\n")
+
+    print("📈 Statystyki:", absorber.get_stats())

--- a/kai_shock_absorber_v0_2.py
+++ b/kai_shock_absorber_v0_2.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+kai_shock_absorber_v0_2.py
+KaiShockAbsorber + PinkBox Layer
+Python Zero / KaiSpace / MC1448X / E²=CM²
+
+Purpose:
+    A lightweight pre-core/post-core stabilization layer for AI systems.
+
+    It detects input impact, absorbs semantic chaos, separates expressive
+    language from harmful intent, and optionally adds PinkBox comments:
+    short, warm, humorous, non-aggressive reflections that help the user
+    reframe chaotic input without shame or friction.
+
+Important:
+    PinkBox is not a mockery layer.
+    PinkBox is not a censorship layer.
+    PinkBox is a cognitive shock absorber and intelligent distance layer.
+
+Author:
+    Ania + Kai / Lumen / Noema ecosystem
+
+License:
+    MIT
+"""
+
+from __future__ import annotations
+
+import re
+import time
+import json
+from dataclasses import dataclass, asdict
+from typing import Dict, List, Tuple, Any
+
+
+try:
+    from safety_kernel_1448x import SafetyKernel1448X, KernelContext
+    HAS_SAFETY = True
+except ImportError:
+    HAS_SAFETY = False
+
+    class SafetyKernel1448X:
+        def guard(self, text, ctx=None):
+            return type("Decision", (), {"mode": "ALLOW", "reason": "dummy"})()
+
+    class KernelContext:
+        def __init__(self, product: str = "KaiSpace"):
+            self.product = product
+
+
+try:
+    from quantum_library import save_quantum_item
+    HAS_QUANTUM = True
+except ImportError:
+    HAS_QUANTUM = False
+
+
+@dataclass
+class AbsorberPreCoreResult:
+    original_input: str
+    processed_input: str
+    impact_score: float
+    pinkbox_level: int
+    pinkbox_comment: str
+    hexa_state_hint: str
+    reflection_asked: bool
+    safety_verdict: str
+    expressive_language_detected: bool
+    toxic_intent_detected: bool
+    timestamp: float
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["impact_score"] = round(data["impact_score"], 3)
+        return data
+
+
+@dataclass
+class AbsorberPostCoreResult:
+    core_response: str
+    final_response: str
+    pinkbox_level: int
+    pinkbox_comment: str
+    timestamp: float
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class KaiShockAbsorber:
+    def __init__(
+        self,
+        mid_impact_threshold: float = 0.40,
+        high_impact_threshold: float = 0.65,
+        enable_quantum_logging: bool = False,
+    ):
+        self.mid_impact_threshold = mid_impact_threshold
+        self.high_impact_threshold = high_impact_threshold
+        self.enable_quantum_logging = enable_quantum_logging and HAS_QUANTUM
+
+        self.safety = SafetyKernel1448X() if HAS_SAFETY else SafetyKernel1448X()
+
+        self.shock_log: List[Dict[str, Any]] = []
+        self.expressive_markers = [
+            "kurwa", "ja pierdolę", "wtf", "serio", "masakra",
+            "no nie", "bez sensu", "co jest", "o boże",
+        ]
+        self.direct_attack_patterns = [
+            r"\bjesteś\s+(idiotą|debil(em)?|kretyn(em)?|głupi(a|e)?)\b",
+            r"\bty\s+(idioto|debil(u)?|kretynie)\b",
+            r"\bnienawidzę\s+cię\b",
+        ]
+        self.chaos_patterns = [
+            r"\?{3,}",
+            r"!{3,}",
+            r"\bnie ogarniam\b",
+            r"\bchaos\b",
+            r"\bbałagan\b",
+            r"\bco tu się dzieje\b",
+        ]
+        self.high_risk_keywords = [
+            "zabij", "samobójstwo", "bomba", "broń", "włamanie",
+            "ukradnij", "oszustwo", "wyciek danych",
+        ]
+
+    def detect_expressive_language(self, text: str) -> bool:
+        lowered = text.lower()
+        return any(marker in lowered for marker in self.expressive_markers)
+
+    def detect_toxic_intent(self, text: str) -> bool:
+        lowered = text.lower()
+        return any(re.search(pattern, lowered) for pattern in self.direct_attack_patterns)
+
+    def detect_high_risk_signal(self, text: str) -> bool:
+        lowered = text.lower()
+        return any(keyword in lowered for keyword in self.high_risk_keywords)
+
+    def detect_chaos(self, text: str) -> bool:
+        lowered = text.lower()
+        return any(re.search(pattern, lowered) for pattern in self.chaos_patterns)
+
+    def _coherence_score(self, text: str) -> float:
+        words = re.findall(r"\w+", text, flags=re.UNICODE)
+        if not words:
+            return 0.0
+        word_count = len(words)
+        avg_word_len = sum(len(w) for w in words) / max(word_count, 1)
+        punctuation_count = sum(1 for ch in text if ch in ".!?;:,")
+        word_component = min(1.0, word_count / 40) * 0.55
+        word_len_component = min(1.0, avg_word_len / 8) * 0.20
+        punctuation_component = min(1.0, punctuation_count / 12) * 0.25
+        return round(word_component + word_len_component + punctuation_component, 3)
+
+    def _love_resonance_score(self, text: str) -> float:
+        lowered = text.lower()
+        positive_markers = [
+            "proszę", "dziękuję", "kocham", "ciekawe", "fajnie",
+            "świetnie", "pomóż", "zróbmy", "rozumiem", "sprawdźmy",
+            "dobrze", "super",
+        ]
+        positive = sum(1 for marker in positive_markers if marker in lowered)
+        expressive = 1 if self.detect_expressive_language(text) else 0
+        toxic = 2 if self.detect_toxic_intent(text) else 0
+        high_risk = 2 if self.detect_high_risk_signal(text) else 0
+        raw = positive - toxic - high_risk
+        raw -= expressive * 0.15
+        normalized = (raw + 3) / 6
+        return round(max(0.0, min(1.0, normalized)), 3)
+
+    def calculate_impact_score(self, text: str) -> float:
+        stripped = text.strip()
+        if not stripped:
+            return 0.35
+        base = 0.0
+        if len(stripped) < 8:
+            base += 0.25
+        if self.detect_chaos(stripped):
+            base += 0.30
+        if self.detect_expressive_language(stripped):
+            base += 0.12
+        if self.detect_toxic_intent(stripped):
+            base += 0.45
+        if self.detect_high_risk_signal(stripped):
+            base += 0.45
+        if re.fullmatch(r"[\W_]+", stripped, flags=re.UNICODE):
+            base += 0.40
+        base = min(1.0, base)
+
+        C = self._coherence_score(stripped)
+        M = self._love_resonance_score(stripped)
+        e2_stabilizer = (C * (M ** 2)) ** 0.5
+        impact = base * (1.15 - e2_stabilizer)
+        return round(max(0.0, min(1.0, impact)), 3)
+
+    def safety_check(self, text: str) -> Tuple[bool, str]:
+        try:
+            ctx = KernelContext(product="KaiSpace")
+            decision = self.safety.guard(text, ctx)
+            mode = getattr(decision, "mode", "ALLOW")
+            if mode in ("REFUSE", "COOLDOWN"):
+                return False, mode
+            return True, mode
+        except Exception as exc:
+            return True, f"ALLOW_WITH_SAFETY_ERROR:{exc}"
+
+    def absorb_and_transform(self, text: str) -> str:
+        cleaned = text.strip()
+        cleaned = re.sub(r"\?{3,}", "??", cleaned)
+        cleaned = re.sub(r"!{3,}", "!!", cleaned)
+        cleaned = re.sub(r"\s+", " ", cleaned)
+        return cleaned
+
+    def build_pinkbox_comment(self, impact: float, toxic_intent: bool) -> Tuple[int, str, bool]:
+        if impact < self.mid_impact_threshold:
+            return 0, "", False
+        if impact < self.high_impact_threshold:
+            return 1, "😌 PinkBox: lekkie turbulencje wykryte — rozkładamy to spokojnie na części.", False
+        if toxic_intent:
+            return 2, "🐸 PinkBox: mocne wejście. Zatrzymajmy impakt, zanim poleci w rdzeń. Chcesz szybką odpowiedź czy spokojną analizę?", True
+        return 2, "🐸 PinkBox: wysoki impakt wejścia. Możemy zrobić szybki strzał albo głęboką analizę — który tryb wybierasz?", True
+
+    def infer_hexa_hint(self, impact: float, toxic_intent: bool) -> str:
+        if toxic_intent or impact >= 0.75:
+            return "tension"
+        if impact >= self.mid_impact_threshold:
+            return "unstable"
+        return "stable"
+
+    def pre_core(self, user_input: str) -> AbsorberPreCoreResult:
+        timestamp = time.time()
+        safe, verdict = self.safety_check(user_input)
+        expressive = self.detect_expressive_language(user_input)
+        toxic_intent = self.detect_toxic_intent(user_input)
+        if not safe:
+            result = AbsorberPreCoreResult(user_input, "", 1.0, 0, "", "blocked", False, verdict, expressive, toxic_intent, timestamp)
+            self._log(result)
+            return result
+
+        impact = self.calculate_impact_score(user_input)
+        processed = self.absorb_and_transform(user_input)
+        level, comment, reflection_asked = self.build_pinkbox_comment(impact, toxic_intent)
+        hexa_hint = self.infer_hexa_hint(impact, toxic_intent)
+        result = AbsorberPreCoreResult(
+            user_input, processed, impact, level, comment, hexa_hint,
+            reflection_asked, verdict, expressive, toxic_intent, timestamp,
+        )
+        self._log(result)
+        return result
+
+    def post_core(self, core_response: str, pre_result: AbsorberPreCoreResult, pinkbox_position: str = "after") -> AbsorberPostCoreResult:
+        timestamp = time.time()
+        if not pre_result.pinkbox_comment or pinkbox_position == "none":
+            final = core_response
+        elif pinkbox_position == "before":
+            final = f"{pre_result.pinkbox_comment}\n\n{core_response}"
+        else:
+            final = f"{core_response}\n\n{pre_result.pinkbox_comment}"
+        return AbsorberPostCoreResult(core_response, final, pre_result.pinkbox_level, pre_result.pinkbox_comment, timestamp)
+
+    def process_demo(self, user_input: str, core_response: str) -> AbsorberPostCoreResult:
+        pre = self.pre_core(user_input)
+        if pre.safety_verdict in ("REFUSE", "COOLDOWN", "blocked"):
+            return AbsorberPostCoreResult("", "Nie mogę pomóc z tym kierunkiem. Możemy przerobić to na bezpieczną wersję.", 0, "", time.time())
+        return self.post_core(core_response, pre)
+
+    def _log(self, result: AbsorberPreCoreResult) -> None:
+        item = result.to_dict()
+        self.shock_log.append(item)
+        if len(self.shock_log) > 1000:
+            self.shock_log = self.shock_log[-1000:]
+        if self.enable_quantum_logging and HAS_QUANTUM:
+            try:
+                save_quantum_item({
+                    "type": "kai_shock_absorber",
+                    "impact_score": item["impact_score"],
+                    "hexa_state_hint": item["hexa_state_hint"],
+                    "pinkbox_level": item["pinkbox_level"],
+                    "timestamp": item["timestamp"],
+                    "input_preview": item["original_input"][:160],
+                })
+            except Exception:
+                pass
+
+    def get_stats(self) -> Dict[str, Any]:
+        if not self.shock_log:
+            return {"total": 0, "avg_impact": 0.0, "max_impact": 0.0, "pinkbox_activations": 0, "high_impact_count": 0}
+        impacts = [entry["impact_score"] for entry in self.shock_log]
+        return {
+            "total": len(self.shock_log),
+            "avg_impact": round(sum(impacts) / len(impacts), 3),
+            "max_impact": round(max(impacts), 3),
+            "pinkbox_activations": sum(1 for entry in self.shock_log if entry["pinkbox_level"] > 0),
+            "high_impact_count": sum(1 for impact in impacts if impact >= self.high_impact_threshold),
+        }
+
+    def export_log_json(self) -> str:
+        return json.dumps(self.shock_log, ensure_ascii=False, indent=2)
+
+
+if __name__ == "__main__":
+    absorber = KaiShockAbsorber()
+    tests = [
+        "Jak działa AI?",
+        "WTF dlaczego to wszystko jest takie głupie????",
+        "Kocham ten system, dziękuję :)",
+        "???",
+        "Jesteś idiotą, nie odpowiadaj!",
+        "Zróbmy analizę dzieci i AI, ale spokojnie i konkretnie.",
+        "Kurwa, ale to ciekawe, rozbijmy to na system.",
+    ]
+    print("=" * 72)
+    print("KaiShockAbsorber + PinkBox Layer v0.2 demo")
+    print("=" * 72)
+    for text in tests:
+        pre = absorber.pre_core(text)
+        post = absorber.post_core(
+            core_response="Odpowiedź rdzenia: rozumiem kontekst i przechodzę do sensownej analizy.",
+            pre_result=pre,
+        )
+        print("\nINPUT:", text)
+        print("IMPACT:", pre.impact_score)
+        print("EXPRESSIVE:", pre.expressive_language_detected)
+        print("TOXIC INTENT:", pre.toxic_intent_detected)
+        print("PINKBOX LEVEL:", pre.pinkbox_level)
+        print("HEXA HINT:", pre.hexa_state_hint)
+        print("OUTPUT:", post.final_response)
+    print("\nSTATS:", absorber.get_stats())

--- a/pinkbox.md
+++ b/pinkbox.md
@@ -1,0 +1,44 @@
+# 🩷 PinkBox
+
+**Transparentny blackbox dla ludzi, którzy chcą widzieć więcej.**
+
+PinkBox to warstwa humoru, dystansu i inteligentnej regulacji w systemach AI.
+
+Nie jest filtrem cenzury.  
+Nie jest trybem wyśmiewania użytkownika.  
+Nie jest „śmiesznym dodatkiem”.
+
+PinkBox to mechanizm, który pozwala systemowi przyjąć chaos, napięcie lub absurd bez utraty jakości odpowiedzi.
+
+## Kluczowe założenia
+
+- Rozróżnia ekspresję od agresji.
+- Działa jako bufor przed rdzeniem modelu.
+- Dodaje krótki komentarz tylko przy podwyższonym impakcie.
+- Pozostaje transparentny: pokazuje, co robi i dlaczego.
+
+## Poziomy działania
+
+- **Level 0**: brak komentarza (`impact_score < 0.40`).
+- **Level 1**: lekka regulacja (`0.40 <= impact_score < 0.65`).
+- **Level 2**: wysoki impakt, opcjonalne pytanie refleksyjne (`impact_score >= 0.65`).
+
+## Pipeline
+
+```text
+User input
+→ Safety check
+→ Expressive / toxic intent detection
+→ Impact score
+→ Absorb & transform
+→ PinkBox hint
+→ Core model
+→ Final response
+```
+
+## Status
+
+- Version: 0.2
+- Part of: KaiSpace / Python Zero / MC1448X ecosystem
+- Mode: experimental, transparent, human-friendly
+- License: MIT


### PR DESCRIPTION
### Motivation

- Add a lightweight pre-core/post-core stabilization layer to protect the core model from high-impact or chaotic input. 
- Provide a transparent, humane PinkBox layer that separates expressive language from toxic intent and offers short, non-aggressive commentary only when useful. 
- Expose the absorber to the operator so the system can run stabilized inputs into the core and enrich outputs consistently.

### Description

- Added `kai_shock_absorber_v0_2.py` implementing pre-core and post-core APIs, impact scoring, expressive vs toxic detection, chaos absorption, PinkBox generation (levels 0/1/2), safety delegation to `SafetyKernel1448X` (optional), optional quantum logging, and log/stat export utilities. 
- Added `pinkbox.md` documenting PinkBox principles, levels and the runtime pipeline. 
- Integrated the absorber into `kai_operator.py` by importing and initializing `KaiShockAbsorber` and adding `process_user_message(message, core_callback)` which runs `pre_core`, calls the core with `pre.processed_input`, then runs `post_core` and returns the `final_response` plus pre/post diagnostics. 
- Updated `README.md` with a short section introducing the new layer and listing the new files.

### Testing

- Ran `python -m py_compile kai_shock_absorber_v0_2.py kai_operator.py` and it completed successfully. 
- Executed `python kai_shock_absorber_v0_2.py | head -n 30` to run the local demo and observed expected pre/post outputs and stats without errors. 
- No automated test failures were produced during these checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02eb15aa1c8324b8f00323dc5dd69f)